### PR TITLE
Add options to include vendor files or all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ target-directory *| The target directory where the results are stored
 personal-access-token* | The personal access token, generated on [PHP-Prefixer](https://php-prefixer.com/) Settings
 project-id * | The identification of the configured project on [PHP-Prefixer](https://php-prefixer.com/) Projects
 --github-access-token | An optional GitHub token to access ´composer.json´ dependencies that are managed in private repositories
+--include-vendor | include the local preinstalled vendor direcory in the build
+--include-all | include all files from the source direcory instead of only composer relevant and php files
 
 ```bash
 # Sample command-line
@@ -90,7 +92,9 @@ project-id * | The identification of the configured project on [PHP-Prefixer](ht
 \
     123456 \
 \
-    --github-access-token=1234567890123456789012345678901234567890
+    --github-access-token=1234567890123456789012345678901234567890 \
+\
+    --include-vendor
 ```
 
 ### Environment Variables

--- a/app/Commands/PrefixCommand.php
+++ b/app/Commands/PrefixCommand.php
@@ -35,6 +35,8 @@ class PrefixCommand extends Command
         {project-id : The project ID to process the source code}
         {--github-access-token= : Github access token for private repositories}
         {--delete-build : Delete the build after download}
+        {--include-vendor : Include preinstalled vendor in the build}
+        {--include-all : Include all files in the build instead of only php and composer files}
     ';
 
     /**
@@ -102,10 +104,14 @@ class PrefixCommand extends Command
 
         $deleteBuild = (bool) $this->option('delete-build');
 
+        $includeVendor = (bool) $this->option('include-vendor');
+
+        $includeAll = (bool) $this->option('include-all');
+
         $processor = new Processor($personalAccessToken);
 
         try {
-            $build = $processor->run($sourceDirectory, $targetDirectory, $projectId, $githubAccessToken);
+            $build = $processor->run($sourceDirectory, $targetDirectory, $projectId, $githubAccessToken, $includeVendor, $includeAll);
         } catch (\GuzzleHttp\Exception\ClientException $clientException) {
             if (!$clientException->hasResponse()) {
                 $this->error('PHP-Prefixer: '.$clientException->getMessage());
@@ -151,6 +157,8 @@ class PrefixCommand extends Command
         $this->argumentOrEnv($input, 'project-id');
         $this->optionOrEnv($input, 'github-access-token');
         $this->optionOrEnv($input, 'delete-build');
+        $this->optionOrEnv($input, 'include-vendor');
+        $this->optionOrEnv($input, 'include-all');
     }
 
     private function argumentOrEnv($input, $key)

--- a/app/Support/Processor.php
+++ b/app/Support/Processor.php
@@ -26,9 +26,12 @@ class Processor
         $this->prefixerClient = (new PrefixerClient())->authenticate($this->personalAccessToken);
     }
 
-    public function run($sourcePath, $targetPath, int $projectId, $githubAccessToken = null)
+    public function run($sourcePath, $targetPath, int $projectId, $githubAccessToken = null, $includeVendor = false, $includeAll = false)
     {
         $zipManager = new ZipManager();
+        $zipManager->includeVendor( $includeVendor );
+        $zipManager->includeAll( $includeAll );
+
         $tmpZip = $this->temporaryZipFilename($targetPath);
         $zipManager->compress($sourcePath, $tmpZip);
 


### PR DESCRIPTION
My PHP source has a modified vendor direcory as well as some required text files, which has to be in the built output. For this, I need to send the full source directory to PHP-Prefixer. 

This PR adds two CLI options to include either the vendor directory in the build or include all files (including non-php files), which works perfectly for me. The added options are `--include-vendor` and `--include-all`.

I'm happy to hear, what you think! ✌🏼 